### PR TITLE
Widen the range of acceptable reek versions

### DIFF
--- a/lib/pronto/reek.rb
+++ b/lib/pronto/reek.rb
@@ -5,7 +5,7 @@ module Pronto
   class Reek < Runner
     def run
       files = ruby_patches.map(&:new_file_full_path)
-      configuration = ::Reek::Configuration::AppConfiguration.from_path
+      configuration = ::Reek::Configuration::AppConfiguration.from_path(nil)
 
       smells = files.flat_map do |file|
         ::Reek::Examiner.new(file, configuration: configuration).smells

--- a/pronto-reek.gemspec
+++ b/pronto-reek.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency('pronto', '~> 0.9.0')
-  s.add_dependency('reek', '~> 4.2')
+  s.add_dependency('reek', '>= 4.2', '< 6.0')
   s.add_development_dependency('rake', '~> 12.0')
   s.add_development_dependency('rspec', '~> 3.4')
   s.add_development_dependency('rspec-its', '~> 1.2')


### PR DESCRIPTION
Fix:

```bash
Bundler could not find compatible versions for gem "reek":
  In snapshot (Gemfile.lock):
    reek (= 5.0.2)

  In Gemfile:
    reek (~> 5.0.2)

    pronto-reek was resolved to 0.9.0, which depends on
      reek (~> 4.2)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```


Looks like [Reek::Configuration::AppConfiguration.from_path]( https://github.com/troessner/reek/blob/b37a94c/lib/reek/configuration/app_configuration.rb#L28) used to default to nil but now it does not. Therefore I changed the code in a way it forces nil, which still seems to be ok, judging by the bellow files:
 
-  [AppConfiguration.from_path](https://github.com/troessner/reek/blob/ae8e3e630f23d13cf6b793d5378fa151e30381bc/lib/reek/configuration/app_configuration.rb#L29) ->  [ConfigurationFileFinder. find_and_load](https://github.com/troessner/reek/blob/ae8e3e630f23d13cf6b793d5378fa151e30381bc/lib/reek/configuration/configuration_file_finder.rb#L31)

