### PR TITLE
Allow latest release of reek, 6.0.0

### DIFF
--- a/pronto-reek.gemspec
+++ b/pronto-reek.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency('pronto', '~> 0.10.0')
-  s.add_dependency('reek', '>= 4.2', '< 6.0')
+  s.add_dependency('reek', '>= 4.2', '< 7.0')
   s.add_development_dependency('rake', '~> 12.0')
   s.add_development_dependency('rspec', '~> 3.4')
   s.add_development_dependency('rspec-its', '~> 1.2')


### PR DESCRIPTION
The only change of concern is dropping support for Ruby 2.3, which is no reason to not allow people to use it.

Ref: https://github.com/troessner/reek/blob/master/CHANGELOG.md#600-2020-03-30