### PR TITLE
Allow latest release of reek, 6.0.0

### DIFF
--- a/pronto-reek.gemspec
+++ b/pronto-reek.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency('pronto', '~> 0.10.0')
-  s.add_dependency('reek', '>= 4.2', '< 6.0')
+  s.add_dependency('reek', '>= 4.2', '< 7.0')
   s.add_development_dependency('rake', '~> 12.0')
   s.add_development_dependency('rspec', '~> 3.4')
   s.add_development_dependency('rspec-its', '~> 1.2')

--- a/spec/pronto/reek_spec.rb
+++ b/spec/pronto/reek_spec.rb
@@ -24,13 +24,13 @@ module Pronto
 
         its(:count) { should == 2 }
         its(:'first.msg') do
-          should ==
-            "Has the parameter name 'n' - [UncommunicativeParameterName](https://github.com/troessner/reek/blob/v5.6.0/docs/Uncommunicative-Parameter-Name.md)"
+          should \
+            match(/Has the parameter name 'n' - \[UncommunicativeParameterName\]\(https:\/\/github.com\/troessner\/reek\/blob\/v\d+\.\d+\.\d+\/docs\/Uncommunicative-Parameter-Name.md\)/)
         end
 
         its(:'last.msg') do
-          should ==
-            "Has the variable name '@n' - [UncommunicativeVariableName](https://github.com/troessner/reek/blob/v5.6.0/docs/Uncommunicative-Variable-Name.md)"
+          should \
+            match(/Has the variable name '@n' - \[UncommunicativeVariableName\]\(https:\/\/github.com\/troessner\/reek\/blob\/v\d+\.\d+\.\d+\/docs\/Uncommunicative-Variable-Name.md\)/)
         end
       end
 


### PR DESCRIPTION
The only change of concern is dropping support for Ruby 2.3, which is no reason to not allow people to use it.

Ref: https://github.com/troessner/reek/blob/master/CHANGELOG.md#600-2020-03-30

Replaces https://github.com/prontolabs/pronto-reek/pull/26