### PR TITLE
Add configurable message severity

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,12 @@ Pronto runner for [Reek](https://github.com/troessner/reek), code smell detector
 ## Configuration
 
 Configuring Reek via [config.reek](https://github.com/troessner/reek#configuration-file), or any file ending with .reek, will work just fine with pronto-reek.
+
+You can also specify a custom severity level for the reek smells with the environment variable PRONTO_REEK_SEVERITY_LEVEL.
+
+Or if you prefer provide it on your `.pronto.yml` (environment variable has precedence over file):
+
+```yaml
+reek:
+  severity_level: warning # default is info
+```

--- a/lib/pronto/reek.rb
+++ b/lib/pronto/reek.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pronto'
 require 'reek'
 
@@ -35,13 +37,19 @@ module Pronto
       path = line.patch.delta.new_file[:path]
       message = "#{error.message.capitalize} - [#{error.smell_type}](#{error.explanatory_link})"
 
-      Message.new(path, line, :info, message, nil, self.class)
+      Message.new(path, line, severity_level, message, nil, self.class)
     end
 
     def patch_for_error(error)
       ruby_patches.find do |patch|
         patch.new_file_full_path.relative_path_from(Pathname.pwd).to_s == error.source
       end
+    end
+
+    def severity_level
+      @severity_level ||= begin
+        ENV['PRONTO_REEK_SEVERITY_LEVEL'] || Pronto::ConfigFile.new.to_h.dig('reek', 'severity_level') || :info
+      end.to_sym
     end
   end
 end

--- a/spec/pronto/reek_spec.rb
+++ b/spec/pronto/reek_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module Pronto
@@ -31,6 +33,18 @@ module Pronto
         its(:'last.msg') do
           should \
             match(/Has the variable name '@n' - \[UncommunicativeVariableName\]\(https:\/\/github.com\/troessner\/reek\/blob\/v\d+\.\d+\.\d+\/docs\/Uncommunicative-Variable-Name.md\)/)
+        end
+
+        context 'when severity level configured on environment variable' do
+          before { stub_const('ENV', 'PRONTO_REEK_SEVERITY_LEVEL' => 'fatal') }
+
+          its(:'first.level') { should == :fatal }
+        end
+
+        context 'when severity level configured on file' do
+          before { Pronto::ConfigFile.stub(:new).and_return('reek' => { 'severity_level' => 'error' }) }
+
+          its(:'first.level') { should == :error }
         end
       end
 


### PR DESCRIPTION
Addresses #15

Having messages reported with a severity higher than `:info` makes pronto exit with an exit code other than 0 (when `--exit-code` option is used). This is very important to, for an example, [use pronto-reek along Overcommit](https://github.com/sds/overcommit/issues/754) (which is my motivation)